### PR TITLE
time.Kitchen has been added to layouts map

### DIFF
--- a/src/datetime/nodes/common.go
+++ b/src/datetime/nodes/common.go
@@ -14,5 +14,6 @@ var (
 		"RFC1123Z":    time.RFC1123Z,
 		"RFC3339":     time.RFC3339,
 		"RFC3339Nano": time.RFC3339Nano,
+		"Kitchen":     time.Kitchen,
 	}
 )


### PR DESCRIPTION
The predefined constant time.Kitchen is intended for future implementations - as part of merge request practices.