### PR TITLE
ci: set least-privilege GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   Build:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Adds explicit `permissions:` blocks to workflows flagged by code scanning (`actions/missing-workflow-permissions`), scoped to what each workflow needs. selenium/contrib only checkout+push to external registries (`contents: read`); v8go v8upgrade auto-opens a PR via peter-evans (`contents: write` + `pull-requests: write`).